### PR TITLE
Fix nested scroll in inverted VirtualizedList

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -810,12 +810,29 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     // REACT-NATIVE-WEB patch to preserve during future RN merges: Support inverted wheel scroller.
     // For issue https://github.com/necolas/react-native-web/issues/995
     this.invertedWheelEventHandler = (ev: any) => {
+      const scrollOffset = this.props.horizontal ? ev.target.scrollLeft : ev.target.scrollTop;
+      const scrollLength = this.props.horizontal ? ev.target.scrollWidth : ev.target.scrollHeight;
+      const clientLength = this.props.horizontal ? ev.target.clientWidth : ev.target.clientHeight;
+      const isEventTargetScrollable = scrollLength > clientLength;
+      const delta = this.props.horizontal
+        ? ev.deltaX || ev.wheelDeltaX
+        : ev.deltaY || ev.wheelDeltaY;
+      let leftoverDelta = delta;
+      if (isEventTargetScrollable) {
+        leftoverDelta = delta < 0
+          ? Math.min(delta + scrollOffset, 0)
+          : Math.max(delta - (scrollLength - clientLength - scrollOffset), 0);
+      }
+      const targetDelta = delta - leftoverDelta;
+
       if (this.props.inverted && this._scrollRef && this._scrollRef.getScrollableNode) {
         const node = (this._scrollRef: any).getScrollableNode();
         if (this.props.horizontal) {
-          node.scrollLeft -= ev.deltaX || ev.wheelDeltaX
+          ev.target.scrollLeft += targetDelta;
+          node.scrollLeft -= leftoverDelta;
         } else {
-          node.scrollTop -= ev.deltaY || ev.wheelDeltaY
+          ev.target.scrollTop += targetDelta;
+          node.scrollTop -= leftoverDelta;
         }
         ev.preventDefault();
       }


### PR DESCRIPTION
Fixes https://github.com/necolas/react-native-web/issues/2435

### Details
[This workaround](https://github.com/necolas/react-native-web/commit/7ec2489c78f9734bae5bcfdc514b0c91621a6300) fixes wheel events in inverted FlatLists, but overrides the default (global) wheel event handler for inputs. Therefore, if you have a scrollable node as a child of an inverted FlatList, the scroll on that node is broken unless you employ a workaround by adding a wheel event listener to the child as well.

This PR fixes the workaround for wheel events in inverted FlatList by:

1. Calculate the scroll in the event target (if any)
1. Calculate the "leftover scroll" in excess of the target scroll bounds (if any)
1. Applies the inverse of the "leftover scroll" on the FlatList