### PR TITLE
Fix: Safari Keyboard open/close viewport height update

### DIFF
--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -80,6 +80,13 @@ export default class Dimensions {
     let height;
     let width;
 
+    /*
+     * iOS does not update viewport dimensions on keyboard open/close
+     * So, we are using window.visualViewport(https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport)
+     * instead of document.documentElement.clientHeight
+     * But we are still using document.documentElement.clientWidth as fallback
+     * because it was requested by the original repo owner
+     */
     if (win.visualViewport) {
       const visualViewport = win.visualViewport;
       height = Math.round(visualViewport.height);
@@ -136,6 +143,10 @@ export default class Dimensions {
 }
 
 if (canUseDOM) {
+  /*
+   * Same here as in _update method
+   * keeping the previous implementation as fallback
+   */
   if (window.visualViewport) {
     window.visualViewport.addEventListener('resize', Dimensions._update, false);
   } else {

--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -84,8 +84,7 @@ export default class Dimensions {
      * iOS does not update viewport dimensions on keyboard open/close
      * So, we are using window.visualViewport(https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport)
      * instead of document.documentElement.clientHeight
-     * But we are still using document.documentElement.clientWidth as fallback
-     * because it was requested by the original repo owner
+     * document.documentElement.clientWidth is used as a fallback
      */
     if (win.visualViewport) {
       const visualViewport = win.visualViewport;
@@ -144,8 +143,8 @@ export default class Dimensions {
 
 if (canUseDOM) {
   /*
-   * Same here as in _update method
-   * keeping the previous implementation as fallback
+   * Same as in _update method, we are
+   * keeping the previous implementation as a fallback
    */
   if (window.visualViewport) {
     window.visualViewport.addEventListener('resize', Dimensions._update, false);

--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -77,13 +77,24 @@ export default class Dimensions {
     }
 
     const win = window;
-    const docEl = win.document.documentElement;
+    let height;
+    let width;
+
+    if (win.visualViewport) {
+      const visualViewport = win.visualViewport;
+      height = Math.round(visualViewport.height);
+      width = Math.round(visualViewport.width);
+    } else {
+      const docEl = win.document.documentElement;
+      height = docEl.clientHeight;
+      width = docEl.clientWidth;
+    }
 
     dimensions.window = {
       fontScale: 1,
-      height: docEl.clientHeight,
+      height,
       scale: win.devicePixelRatio || 1,
-      width: docEl.clientWidth
+      width
     };
 
     dimensions.screen = {
@@ -125,5 +136,9 @@ export default class Dimensions {
 }
 
 if (canUseDOM) {
-  window.addEventListener('resize', Dimensions._update, false);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', Dimensions._update, false);
+  } else {
+    window.addEventListener('resize', Dimensions._update, false);
+  }
 }


### PR DESCRIPTION
Fixes: https://github.com/necolas/react-native-web/issues/2430

## Details
This PR fixes the issue we have on iOS, which does not fire Viewport `resize` when keyboard opens/close on mWeb.

The PR is pending in Upstream repo, so I am adding my changes here as advised https://github.com/Expensify/App/issues/11463#issuecomment-1360815468

As we are behind the Upstream repo, I have updated my code to match our fork's version.

I have not added the test as it is still being reviewed by the Upstream repo owner. 


https://user-images.githubusercontent.com/7548730/208975170-390e431e-9fea-49dc-9b4e-38c8c413f10d.mp4

