### PR TITLE
Fix Image Caching

### DIFF
--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -311,7 +311,7 @@ const BaseImage: ImageComponent = React.forwardRef((props, ref) => {
 
     function abortPendingRequest() {
       if (requestRef.current != null) {
-        ImageLoader.abort(requestRef.current);
+        ImageLoader.clear(requestRef.current);
         requestRef.current = null;
       }
     }

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -211,24 +211,18 @@ const BaseImage: ImageComponent = React.forwardRef((props, ref) => {
     }
   }
 
-  const [state, updateState] = React.useState(() => {
-    const uri = resolveAssetUri(source);
-    if (uri != null) {
-      const isLoaded = ImageLoader.has(uri);
-      if (isLoaded) {
-        return LOADED;
-      }
-    }
-    return IDLE;
-  });
-
+  const [state, updateState] = React.useState(IDLE);
   const [layout, updateLayout] = React.useState({});
   const hasTextAncestor = React.useContext(TextAncestorContext);
   const hiddenImageRef = React.useRef(null);
   const filterRef = React.useRef(_filterId++);
   const requestRef = React.useRef(null);
+  const uri = resolveAssetUri(source);
+  const isCached = uri != null && ImageLoader.has(uri);
   const shouldDisplaySource =
-    state === LOADED || (state === LOADING && defaultSource == null);
+    state === LOADED ||
+    isCached ||
+    (state === LOADING && defaultSource == null);
   const [flatStyle, _resizeMode, filter, tintColor] = getFlatStyle(
     style,
     blurRadius,
@@ -281,7 +275,6 @@ const BaseImage: ImageComponent = React.forwardRef((props, ref) => {
   }
 
   // Image loading
-  const uri = resolveAssetUri(source);
   React.useEffect(() => {
     abortPendingRequest();
 

--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -74,12 +74,13 @@ let id = 0;
 const requests = {};
 
 const ImageLoader = {
-  abort(requestId: number) {
-    let image = requests[`${requestId}`];
+  clear(requestId: number) {
+    const image = requests[`${requestId}`];
     if (image) {
       image.onerror = null;
       image.onload = null;
-      image = null;
+      ImageUriCache.remove(image.src);
+      image.src = '';
       delete requests[`${requestId}`];
     }
   },
@@ -102,7 +103,7 @@ const ImageLoader = {
         }
       }
       if (complete) {
-        ImageLoader.abort(requestId);
+        ImageLoader.clear(requestId);
         clearInterval(interval);
       }
     }
@@ -111,7 +112,7 @@ const ImageLoader = {
       if (typeof failure === 'function') {
         failure();
       }
-      ImageLoader.abort(requestId);
+      ImageLoader.clear(requestId);
       clearInterval(interval);
     }
   },
@@ -123,6 +124,7 @@ const ImageLoader = {
     const image = new window.Image();
     image.onerror = onError;
     image.onload = (nativeEvent) => {
+      ImageUriCache.add(uri);
       // avoid blocking the main thread
       const onDecode = () => {
         // Append `source` to match RN's ImageLoadEvent interface
@@ -185,9 +187,8 @@ const ImageLoader = {
       ImageLoader.load(
         uri,
         () => {
-          // Add the uri to the cache so it can be immediately displayed when used
-          // but also immediately remove it to correctly reflect that it has no active references
-          ImageUriCache.add(uri);
+          // load() adds the uri to the cache so it can be immediately displayed when used,
+          // but we also immediately remove it to correctly reflect that it has no active references
           ImageUriCache.remove(uri);
           resolve();
         },


### PR DESCRIPTION
## Description

This PR fixes some subtle inconsistencies around image caching and rendering the same image multiple times

Related to:
- upstream issue: https://github.com/necolas/react-native-web/issues/2492
- App issue: https://github.com/Expensify/App/issues/14278
- upstream PR: https://github.com/necolas/react-native-web/pull/2493

## Test Strategy

Use App's PR to test the changes (https://github.com/Expensify/App/pull/15663)
1. Log into an account on New Expensify
2. Navigate to a chat where you were the last person to send a message
3. Send a message in that chat
4. Confirm that the avatar on the left hand side of the message that you just sent does not flickers.

### Why No Unit Tests

Couldn't easily add unit tests for this change, because the main change is to the `ImageLoader.load` which doesn't have a test suit, and is mocked in the `Image` tests

Existing tests cover the changes in the `Image` component

