### PR TITLE
Fix: onViewableItemsChanged event handler for inverted FlatList

### DIFF
--- a/packages/react-native-web-examples/pages/viewable-items/index.js
+++ b/packages/react-native-web-examples/pages/viewable-items/index.js
@@ -11,6 +11,10 @@ import Example from '../../shared/example';
 
 const ITEMS = [...Array(200)].map((_, i) => `Item ${i}`);
 
+const viewabilityConfig = {
+  itemVisiblePercentThreshold: 95
+};
+
 function createItemRow({ item, index }) {
   return (
     <Pressable key={index} style={[styles.item]}>
@@ -23,26 +27,19 @@ function Divider() {
   return <View style={styles.divider} />;
 }
 
-const viewabilityConfig = {
-  itemVisiblePercentThreshold: 95
-};
-
 function onViewableItemsChanged({ viewableItems, changed }) {
   console.log('Visible items are', viewableItems);
   console.log('Changed in this iteration', changed);
 }
 
 export default function ScrollViewPage() {
-  const scrollRef = React.useRef(null);
   const [isInverted, setIsInverted] = React.useState(true);
 
   return (
     <Example title="ViewableItems Test">
       <View style={styles.container}>
         <Button
-          onPress={() => {
-            setIsInverted((val) => !val);
-          }}
+          onPress={() => setIsInverted((val) => !val)}
           title={isInverted ? 'Inverted Enabled' : 'Inverted Disabled'}
         />
         <FlatList
@@ -50,7 +47,6 @@ export default function ScrollViewPage() {
           data={ITEMS}
           inverted={isInverted}
           onViewableItemsChanged={onViewableItemsChanged}
-          ref={scrollRef}
           renderItem={createItemRow}
           style={styles.scrollView}
           viewabilityConfig={viewabilityConfig}

--- a/packages/react-native-web-examples/pages/viewable-items/index.js
+++ b/packages/react-native-web-examples/pages/viewable-items/index.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  Pressable,
+  View,
+  Button
+} from 'react-native';
+import Example from '../../shared/example';
+
+const ITEMS = [...Array(200)].map((_, i) => `Item ${i}`);
+
+function createItemRow({ item, index }) {
+  return (
+    <Pressable key={index} style={[styles.item]}>
+      <Text style={styles.text}>{item}</Text>
+    </Pressable>
+  );
+}
+
+function Divider() {
+  return <View style={styles.divider} />;
+}
+
+const viewabilityConfig = {
+  itemVisiblePercentThreshold: 95
+};
+
+function onViewableItemsChanged({ viewableItems, changed }) {
+  console.log('Visible items are', viewableItems);
+  console.log('Changed in this iteration', changed);
+}
+
+export default function ScrollViewPage() {
+  const scrollRef = React.useRef(null);
+  const [isInverted, setIsInverted] = React.useState(true);
+
+  return (
+    <Example title="ViewableItems Test">
+      <View style={styles.container}>
+        <Button
+          onPress={() => {
+            setIsInverted((val) => !val);
+          }}
+          title={isInverted ? 'Inverted Enabled' : 'Inverted Disabled'}
+        />
+        <FlatList
+          ItemSeparatorComponent={Divider}
+          data={ITEMS}
+          inverted={isInverted}
+          onViewableItemsChanged={onViewableItemsChanged}
+          ref={scrollRef}
+          renderItem={createItemRow}
+          style={styles.scrollView}
+          viewabilityConfig={viewabilityConfig}
+        />
+      </View>
+    </Example>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'stretch'
+  },
+  scrollView: {
+    backgroundColor: '#eeeeee',
+    maxHeight: 250
+  },
+  item: {
+    margin: 5,
+    padding: 5,
+    backgroundColor: '#cccccc',
+    borderRadius: 3,
+    minWidth: 96
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    margin: 5
+  },
+  divider: {
+    width: '1rem'
+  }
+});

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1424,14 +1424,23 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     }
   };
 
+  _selectClientLength(parentNode) {
+    return !horizontalOrDefault(this.props.horizontal) ? parentNode.clientHeight : parentNode.clientWidth;
+  }
+
   _onCellLayout(e, cellKey, index) {
     const layout = e.nativeEvent.layout;
+    const target = e.nativeEvent.target;
     const next = {
       offset: this._selectOffset(layout),
       length: this._selectLength(layout),
       index,
       inLayout: true,
     };
+
+    if (this.props.inverted) {
+      next.offset = this._selectClientLength(target.parentNode) - next.offset - next.length;
+    }
     const curr = this._frames[cellKey];
     if (
       !curr ||


### PR DESCRIPTION
This pull request solves an [issue](https://github.com/Expensify/App/issues/21811) encountered by @burczu while working on a [this proposal](https://github.com/Expensify/App/issues/18101#issuecomment-1569941817). The problem relates to the `onViewableItemsChanged` event handler, specifically when using an inverted FlatList on the web platform. Currently, the event handler must provide correct results for the list of visible items, leading to inaccurate index determination.

The changes involve adjusting the offset calculation to be in the context of the bottom of the parent element for inverted lists. Implementing these modifications will make the viewableItems calculation accurate for inverted FlatLists on the web platform.

The screenshots highlight the incorrect viewable items in the original implementation and the corrected viewable items after implementing the suggested changes.

Before fix:
<img width="790" alt="Zrzut ekranu 2023-07-18 o 13 30 25" src="https://github.com/Expensify/react-native-web/assets/24796318/573829a3-085c-4bc4-bd60-29e569f4e680">

After fix: 
<img width="801" alt="Zrzut ekranu 2023-07-18 o 13 31 47" src="https://github.com/Expensify/react-native-web/assets/24796318/f07cf969-619a-41cd-909c-624280c6bcde">

